### PR TITLE
Eliminar dependência do Django CMS e correções das versões mínimas dos options

### DIFF
--- a/test_tools/test/__init__.py
+++ b/test_tools/test/__init__.py
@@ -1,5 +1,12 @@
 from .test_case import DjangoTestCase, UnittestTestCase
 from .test_admin import AdminTestCase
 from .test_form import FormTestCase
-from .test_model import ModelTestCase, CMSPluginModelTestCase
-from .test_cms_plugins import CMSPluginTestCase
+from .test_model import ModelTestCase
+
+try:
+    import cms
+except ImportError:
+    pass
+else:
+    from .test_model import CMSPluginModelTestCase
+    from .test_cms_plugins import CMSPluginTestCase

--- a/test_tools/test/test_model.py
+++ b/test_tools/test/test_model.py
@@ -66,17 +66,19 @@ class ModelTestCase(ObjectWithFieldBaseTestCase):
             Option('db_tablespace', settings.DEFAULT_TABLESPACE),
             Option('default_related_name', '%s_set' % (
                 camelcase_to(self.model.__name__, underscore=True)),
-                versao_minima=(1, 7, 0)),
+                versao_minima=(1, 8, 0)),
             Option('get_latest_by', None),
             Option('managed', True),
             Option('order_with_respect_to', None),
             Option('ordering', []),
             Option('permissions', []),
-            Option('default_permissions', (), versao_minima=(1, 7, 0)),
+            Option('default_permissions',
+                   ('add', 'change', 'delete'),
+                   versao_minima=(1, 7, 0)),
             Option('proxy', False),
             Option('select_on_save', False, versao_minima=(1, 6, 0)),
-            Option('unique_together', []),
-            Option('index_together', []),
+            Option('unique_together', ()),
+            Option('index_together', ()),
             Option('verbose_name', camelcase_to(
                 self.model.__name__, space=True)),
             Option('verbose_name_plural', '')


### PR DESCRIPTION
O django-test-tools não deve depender do djangocms, por isso o import foi alterado.
Alguns testes de validação de options dos models falharam porque as versões mínimas dessas options estarem definidas incorretamente e também alguns valores default de options estarem errados.
